### PR TITLE
tcp-passive: Clear connection on child closing

### DIFF
--- a/socket/tcp-bsd.c
+++ b/socket/tcp-bsd.c
@@ -46,6 +46,8 @@
 #include "agent-priv.h"
 #include "socket-priv.h"
 
+#include "tcp-passive.h"
+
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -69,6 +71,7 @@ typedef struct {
   gboolean reliable;
   NiceSocketWritableCb writable_cb;
   gpointer writable_data;
+  NiceSocket *passive_parent;
 } TcpPriv;
 
 #define MAX_QUEUE_LENGTH 20
@@ -223,6 +226,10 @@ socket_close (NiceSocket *sock)
   if (priv->io_source) {
     g_source_destroy (priv->io_source);
     g_source_unref (priv->io_source);
+  }
+
+  if (priv->passive_parent) {
+    nice_tcp_passive_socket_remove_connection (priv->passive_parent, &priv->remote_addr);
   }
 
   nice_socket_free_send_queue (&priv->send_queue);
@@ -460,4 +467,14 @@ socket_send_more (
 
   g_mutex_unlock (&priv->mutex);
   return TRUE;
+}
+
+void
+nice_tcp_bsd_socket_set_passive_parent (NiceSocket *sock, NiceSocket *passive_parent)
+{
+  TcpPriv *priv = sock->priv;
+
+  g_assert (priv->passive_parent == NULL);
+
+  priv->passive_parent = passive_parent;
 }

--- a/socket/tcp-bsd.h
+++ b/socket/tcp-bsd.h
@@ -49,6 +49,9 @@ NiceSocket *
 nice_tcp_bsd_socket_new_from_gsock (GMainContext *ctx, GSocket *gsock,
         NiceAddress *remote_addr, NiceAddress *local_addr, gboolean reliable);
 
+void
+nice_tcp_bsd_socket_set_passive_parent (NiceSocket *socket, NiceSocket *passive_parent);
+
 G_END_DECLS
 
 #endif /* _TCP_BSD_H */

--- a/socket/tcp-passive.c
+++ b/socket/tcp-passive.c
@@ -310,6 +310,8 @@ nice_tcp_passive_socket_accept (NiceSocket *sock)
   if (new_socket) {
     NiceAddress *key = nice_address_dup (&remote_addr);
 
+    nice_tcp_bsd_socket_set_passive_parent (new_socket, sock);
+
     nice_socket_set_writable_callback (new_socket, _child_writable_cb, sock);
     g_hash_table_insert (priv->connections, key, new_socket);
   }
@@ -328,4 +330,11 @@ static guint nice_address_hash (const NiceAddress * key)
   g_free (str);
 
   return hash;
+}
+
+void nice_tcp_passive_socket_remove_connection (NiceSocket *sock, const NiceAddress *to)
+{
+  TcpPassivePriv *priv = sock->priv;
+
+  g_hash_table_remove (priv->connections, to);
 }

--- a/socket/tcp-passive.h
+++ b/socket/tcp-passive.h
@@ -46,6 +46,9 @@ G_BEGIN_DECLS
 NiceSocket * nice_tcp_passive_socket_new (GMainContext *ctx, NiceAddress *addr);
 NiceSocket * nice_tcp_passive_socket_accept (NiceSocket *socket);
 
+void nice_tcp_passive_socket_remove_connection (NiceSocket *socket,
+    const NiceAddress *to);
+
 
 G_END_DECLS
 


### PR DESCRIPTION
If this isn't done, then there may be invalid points left inside the
passive socket which could be used and cause a crash.

Fixes #33